### PR TITLE
Consolidating setup info 

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -22,6 +22,9 @@ jobs:
         scipy-version: ["1.4"]
     steps:
     - uses: actions/checkout@v3
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 20
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
@@ -54,6 +57,9 @@ jobs:
         scipy-version: ["1.10.1"]
     steps:
     - uses: actions/checkout@v3
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 20
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:

--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ surmise is build for Python 3.8 or above, with the following dependencies:
 
 * numpy>=1.18.3
 * scipy>=1.7
-* scikit-learn>=1.2.0
+* (optional) scikit-learn>=1.2.0 (required by emulation method `PCGPR`)
 
 Installation
 ~~~~~~~~~~~~
@@ -36,6 +36,11 @@ Installation
 From the command line, use the following command to install surmise::
 
  pip install surmise
+ pip install surmise[scikit-learn]      # to include scikit-learn in installation
+ pip install surmise[all]               # to include all optional dependencies
+
+The package scikit-learn is required by specific method stated above.
+These packages can be installed along with surmise via the commands listed.
 
 The list of available .whl files can be found under `PyPI-wheel`_.  If a wheel file
 for your preferred platform is not listed, surmise has to be built from source,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,20 @@
+[build-system]
+requires = [
+    "setuptools>=50.0",
+    "setuptools_scm[toml]>=6.0",
+    "numpy>=1.18.3",
+    "cython",
+    "wheel"
+]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "surmise"
 authors = [
     {name = "Matthew Plumlee", email = "mplumlee@northwestern.edu"},
     {name = "Özge Sürer", email = "surero@miamioh.edu"},
     {name = "Stefan M. Wild", email = "wild@lbl.gov"},
-    {name = "Moses Y-H. Chan", email = "mosesyhc@u.northwestern.edu"}    
+    {name = "Moses Y.-H. Chan", email = "moses.chan@northwestern.edu"}
 ]
 description = "A modular interface for surrogate models and tools"
 license = {file = "LICENSE"}
@@ -17,22 +27,23 @@ classifiers = [
 requires-python = ">=3.8"
 dependencies = [
     'numpy>=1.18.3',
-    'scipy>=1.7',
-    'scikit-learn>=1.2.0']
-dynamic = ["version", "optional-dependencies"]
+    'scipy>=1.7'
+]
+dynamic = ["version"]
+
+[project.optional-dependencies]
+docs = [
+    'sphinx',
+    'sphinxcontrib.bibtex',
+    'sphinx_rtd_theme'
+]
+scikit = ['scikit-learn>=1.2.0']
 
 [project.urls]
-Repository = "https://github.com/bandframework/surmise"
+repository = "https://github.com/bandframework/surmise"
 
-[build-system]
-requires = [
-    "setuptools>=50.0",
-    "setuptools_scm[toml]>=6.0",
-    "numpy>=1.18.3",
-    "cython",
-    "wheel"
-]
-build-backend = "setuptools.build_meta"
+[tool.setuptools.packages]
+find = {}
 
 [tool.setuptools_scm]
 write_to = "surmise/_version.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,10 @@ docs = [
     'sphinxcontrib.bibtex',
     'sphinx_rtd_theme'
 ]
-scikit = ['scikit-learn>=1.2.0']
+scikit-learn = ['scikit-learn>=1.2.0']
+all = [
+    'surmise[scikit-learn]'
+]
 
 [project.urls]
 repository = "https://github.com/bandframework/surmise"

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-import setuptools
 from setuptools import setup, Extension
 from setuptools.command.test import test as TestCommand
 import numpy
@@ -14,26 +13,7 @@ class Run_TestSuite(TestCommand):
         os.system(run_string)
 
 
-with open("README.rst", "r", encoding="utf-8") as fh:
-    long_description = fh.read()
-
 setup(
-    name="surmise",
-    # version="0.1.1",
-    packages=setuptools.find_packages(),
-    python_requires='>=3.8',
-    setup_requires=[
-        "setuptools>=50.0",
-        "setuptools_scm[toml]>=6.0",
-        "numpy>=1.18.3",
-        "cython",
-        "wheel"
-    ],
-    install_requires=[
-                      'numpy>=1.18.3',
-                      'scipy>=1.7'
-                      ],
-    extras_require={'docs': ['sphinx', 'sphinxcontrib.bibtex', 'sphinx_rtd_theme']},
     cmdclass={'test': Run_TestSuite},
     ext_modules=[
         Extension('surmise.emulationsupport.matern_covmat',


### PR DESCRIPTION
To avoid maintenance of both setup configuration files, most information have been moved to only exist in pyproject.toml, whereas the C extension and pytest declaration remain in setup.py.