### PR TITLE
py312 failures with distutil import

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,7 +18,7 @@ jobs:
         # Please adjust pyproject.toml Python version requirement to match
         # supported version expressed here.
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.9", "3.10", "3.11"] #, "3.12"]
+        python-version: ["3.12"]  # "3.9", "3.10", "3.11",
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,7 +18,7 @@ jobs:
         # Please adjust pyproject.toml Python version requirement to match
         # supported version expressed here.
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.12"]  # "3.9", "3.10", "3.11",
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools>=50.0",
+    "setuptools>=68.2.2",
     "setuptools_scm[toml]>=6.0",
     "numpy>=1.18.3",
     "cython>=3.0.10",


### PR DESCRIPTION
distutils is discontinued in python 3.12, but available via setuptools.

Re: #123 